### PR TITLE
chore: remove @types/react-chartjs-2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@types/object-path": "^0.11.0",
     "@types/prismjs": "^1.16.2",
     "@types/react": "^17.0.0",
-    "@types/react-chartjs-2": "^2.5.7",
     "@types/react-dom": "^17.0.0",
     "@types/socket.io-client": "^1.4.35",
     "@types/streamsaver": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1952,13 +1952,6 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
-"@types/react-chartjs-2@^2.5.7":
-  version "2.5.7"
-  resolved "https://registry.yarnpkg.com/@types/react-chartjs-2/-/react-chartjs-2-2.5.7.tgz#b77406f6eb6a9f38438966fb27d8cfb1bb7425d3"
-  integrity sha512-waqYqiNULIVUqaKO7MGUpFmWrVtH7gVPOzqwV4y4zgUyu/JiDwC005PpveO442HKnby9kLgp3t1SB2sld+ACLw==
-  dependencies:
-    react-chartjs-2 "*"
-
 "@types/react-dom@^17.0.0":
   version "17.0.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.0.tgz#b3b691eb956c4b3401777ee67b900cb28415d95a"
@@ -10991,14 +10984,6 @@ react-app-rewired@^2.1.8:
   integrity sha512-wjXPdKPLscA7mn0I1de1NHrbfWdXz4S1ladaGgHVKdn1hTgKK5N6EdGIJM0KrS6bKnJBj7WuqJroDTsPKKr66Q==
   dependencies:
     semver "^5.6.0"
-
-react-chartjs-2@*:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/react-chartjs-2/-/react-chartjs-2-2.11.0.tgz#a8aa4ae57f361c4ba4a553649af947ccbe7b57b9"
-  integrity sha512-NONOa+aEwRkDjDEXyVSDbulUtyWy+/5jO+ugFowWMjZVG2Z1DRpx2wBdRlPdVFH04hJs9lH9rFp6Z3NRtVk0GA==
-  dependencies:
-    lodash "^4.17.19"
-    prop-types "^15.7.2"
 
 react-chartjs-2@2.11.1:
   version "2.11.1"


### PR DESCRIPTION
`react-chartjs-2` itself provides type definitions. See [`@types/react-chartjs-2`](https://www.npmjs.com/package/@types/react-chartjs-2).