### PR TITLE
fix: give default value for ScoreText.score

### DIFF
--- a/src/pages/problem/view/common/SubmitViewFrame.tsx
+++ b/src/pages/problem/view/common/SubmitViewFrame.tsx
@@ -61,7 +61,7 @@ let SubmitViewFrame: React.FC<SubmitViewFrameProps> = props => {
               <StatusText status={props.lastSubmission.lastSubmission.status} />
             </Link>
             <Link className={style.scoreText} href={`/s/${props.lastSubmission.lastSubmission.id}`}>
-              <ScoreText score={props.lastSubmission.lastSubmission.score} />
+              <ScoreText score={props.lastSubmission.lastSubmission.score || 0} />
             </Link>
           </div>
         )}


### PR DESCRIPTION
We see that the app usually gives a default value to `ScoreText.score`, here is one example (2 more in the same file):

<https://github.com/syzoj/syzoj-ng-app/blob/62484771c1ed3738acb9042c6cea7e49d8802f1a/src/pages/submission/componments/SubmissionItem.tsx#L97>

However, the default value is not set in the file `SubmitViewFrame.tsx`, as stated in this PR. This will result in a `NaN` score when the last submission is `Cancelled`, which breaks the design (colored score number).

It might be better to set the default value in `SubmitViewFrame.tsx`, but since all the callers are obvious and only one is vulnerable, this PR fixes the vulnerable caller.