### PR TITLE
feat(submission): display a friendly submit time in submission item

### DIFF
--- a/src/pages/submission/componments/SubmissionItem.tsx
+++ b/src/pages/submission/componments/SubmissionItem.tsx
@@ -5,7 +5,7 @@ import style from "./SubmissionItem.module.less";
 
 import { useLocalizer, Link } from "@/utils/hooks";
 import formatFileSize from "@/utils/formatFileSize";
-import formatDateTime from "@/utils/formatDateTime";
+import { friendlyFormatDateTime } from "@/utils/formatDateTime";
 import UserLink from "@/components/UserLink";
 import StatusText from "@/components/StatusText";
 import ScoreText from "@/components/ScoreText";
@@ -17,7 +17,7 @@ function parseSubmissionMeta(submission: ApiTypes.SubmissionMetaDto) {
   return {
     submission,
     submissionLink: `/s/${submission.id}`,
-    timeString: formatDateTime(submission.submitTime),
+    timeString: friendlyFormatDateTime(submission.submitTime),
     problemIdString: getProblemIdString(submission.problem),
     problemUrl: getProblemUrl(submission.problem)
   };

--- a/src/utils/formatDateTime.tsx
+++ b/src/utils/formatDateTime.tsx
@@ -31,3 +31,12 @@ export default function formatDateTime(
 
   return [withoutYear, withYear];
 }
+
+export function friendlyFormatDateTime(date: Date | string | number): [string | JSX.Element, string] {
+  if (!(date instanceof Date)) date = new Date(date);
+
+  const now = new Date();
+  const dateOnlyAndWithYear = date.getFullYear() === now.getFullYear();
+
+  return [formatDateTime(date, dateOnlyAndWithYear)[dateOnlyAndWithYear ? 1 : 0], formatDateTime(date)[1]];
+}


### PR DESCRIPTION
在当前的 LibreOJ 中，一些时间比较久远的提交记录条目上默认显示的时间是 `MM/DD hh:mm:ss` 格式的，虽然在鼠标悬浮到提交时间上时能显示完整的提交时间，但这仍为在提交记录列表中查找提交记录带来了不便。我认为将时间较为久远的提交记录条目上的显示时间更改为 `YYYY/MM/DD` 格式会更有助于查找，故发起此 Pull Request 。